### PR TITLE
Production Nginx config

### DIFF
--- a/.github/workflows/deploy_to_fly.yaml
+++ b/.github/workflows/deploy_to_fly.yaml
@@ -9,6 +9,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
+      - name: Checkout repository with archived sites of previous years
+        uses: actions/checkout@v3
+        with:
+          repository: pyvec/cz.pycon.org-2019
+          path: _previous-years
       - uses: superfly/flyctl-actions/setup-flyctl@master
       - run: flyctl deploy --remote-only
         env:

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,18 +2,18 @@ ARG PYTHON_VERSION=3.10-slim-buster
 
 FROM python:${PYTHON_VERSION}
 
-ENV PYTHONDONTWRITEBYTECODE 1
-ENV PYTHONUNBUFFERED 1
+ENV PYTHONDONTWRITEBYTECODE=1 \
+    PYTHONUNBUFFERED=1
 
-RUN mkdir -p /code
-
+# Workdir is created automatically when necessary.
 WORKDIR /code
 
-COPY requirements.txt /tmp/requirements.txt
-RUN set -ex && \
-    pip install --upgrade pip && \
-    pip install -r /tmp/requirements.txt && \
-    rm -rf /root/.cache/
+# Use of --mount=type=bind reduces number of layers in the Docker image, while maintaining ability to cache the
+# layer with dependencies depending on the contents of requirements.txt file.
+RUN --mount=type=bind,source=./requirements.txt,target=/tmp/requirements.txt \
+    set -ex && \
+    pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir -r /tmp/requirements.txt
 COPY . /code
 
 EXPOSE 8000

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,19 +3,40 @@ ARG PYTHON_VERSION=3.10-slim-buster
 FROM python:${PYTHON_VERSION}
 
 ENV PYTHONDONTWRITEBYTECODE=1 \
-    PYTHONUNBUFFERED=1
+    PYTHONUNBUFFERED=1 \
+    MULTIRUN_VERSION=1.1.3
 
 # Workdir is created automatically when necessary.
 WORKDIR /code
 
+RUN set -ex; \
+    # Install nginx from Debian repository.
+    apt-get update; \
+    apt-get install -y --no-install-recommends \
+        nginx \
+        wget \
+    ; \
+    rm -rf /var/lib/apt/lists/*; \
+    # Download multirun - great for running both nginx and gunicorn in a single container, because it correctly forwards
+    # all signals sent to the container to individual processes.
+    wget -c https://github.com/nicolas-van/multirun/releases/download/${MULTIRUN_VERSION}/multirun-$(arch)-linux-gnu-${MULTIRUN_VERSION}.tar.gz -O - | tar -xz; \
+    mv multirun /bin/multirun;
+
 # Use of --mount=type=bind reduces number of layers in the Docker image, while maintaining ability to cache the
 # layer with dependencies depending on the contents of requirements.txt file.
 RUN --mount=type=bind,source=./requirements.txt,target=/tmp/requirements.txt \
+    --mount=type=bind,source=./docker/nginx/,target=/tmp/nginx-conf/ \
     set -ex && \
     pip install --no-cache-dir --upgrade pip && \
-    pip install --no-cache-dir -r /tmp/requirements.txt
+    pip install --no-cache-dir -r /tmp/requirements.txt && \
+    # Overwrite the configuration of default site in nginx
+    cp /tmp/nginx-conf/cz.pycon.org.conf /etc/nginx/sites-available/default && \
+    # Configure logging for nginx
+    sed -i 's|access_log /var/log/nginx/access.log;|access_log /dev/stdout combined;|g' /etc/nginx/nginx.conf && \
+    sed -i 's|error_log /var/log/nginx/error.log;|error_log /dev/stdout info;|g' /etc/nginx/nginx.conf && \
+    echo "error_log /dev/stdout info;" >> /etc/nginx/nginx.conf
 COPY . /code
 
 EXPOSE 8000
 
-CMD ["gunicorn", "--bind", ":8000", "--workers", "2", "wsgi"]
+CMD ["multirun", "gunicorn --bind unix:/code/gunicorn.sock --workers 2 wsgi", "nginx -g \"daemon off;\""]

--- a/docker/nginx/cz.pycon.org.conf
+++ b/docker/nginx/cz.pycon.org.conf
@@ -1,0 +1,66 @@
+server
+{
+    listen 8000 default_server;
+    listen [::]:8000 default_server;
+
+    # Do not include server name and port in redirects.
+    absolute_redirect off;
+
+    # Do not expose the nginx version in headers and error pages.
+    server_tokens off;
+
+    # Configure gzip compression.
+    gzip on;
+    gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
+
+    # Redirect to the current year.
+    location = /
+    {
+        return 302 /2023/;
+    }
+
+    # Serve current year from Wagtail application.
+    location /2023
+    {
+        proxy_pass http://unix:/code/gunicorn.sock;
+        proxy_redirect default;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header Host $host;
+
+        # Increase maximum body size for file uploads.
+        client_max_body_size 50m;
+    }
+
+    location /static
+    {
+        alias /code/static;
+        # Static assets, such as stylesheets ans JS, should be immutable. Cache for a long time.
+        expires 365d;
+        add_header Cache-Control public;
+    }
+
+    location /media
+    {
+        alias /code/data/mediafiles;
+        # Media, such as images, should be immutable. Cache for a long time.
+        expires 365d;
+        add_header Cache-Control public;
+    }
+
+    # Covid years no pycon, redirect to 2020.
+    location ~ ^/(2021|2022)/?(.*)$
+    {
+        return 302 /2020/;
+    }
+
+    # Static copies of older websites
+    location ~ ^/(2015|2016|2017|2018|2019|2020)($|/)
+    {
+        root /code/_previous-years;
+        index index.html;
+
+        # Require revalidation when accessing the resource - they might change in the upstream repository.
+        add_header Cache-Control "no-cache";
+        expires 1m;
+    }
+}

--- a/urls.py
+++ b/urls.py
@@ -16,16 +16,18 @@ Including another URLconf
 from django.conf import settings
 from django.conf.urls.static import static
 from django.contrib import admin
-from django.urls import include, re_path
+from django.urls import include, path
 
 urlpatterns = [
-    re_path("admin/", admin.site.urls),
-    re_path(r"^wagtail/", include("wagtail.admin.urls")),
-    re_path(r"^team/", include("team.urls")),
-    re_path(r"^sponsors/", include("sponsors.urls")),
-    re_path(r"^announcements/", include("announcements.urls")),
-    re_path(r"^program/", include("program.urls")),
-    re_path(r"^intermissions/", include("intermissions.urls")),
+    path('2023/', include([
+        path("admin/", admin.site.urls),
+        path("wagtail/", include("wagtail.admin.urls")),
+        path("team/", include("team.urls")),
+        path("sponsors/", include("sponsors.urls")),
+        path("announcements/", include("announcements.urls")),
+        path("program/", include("program.urls")),
+        path("intermissions/", include("intermissions.urls")),
+    ])),
 ]
 
 if settings.DEBUG:


### PR DESCRIPTION
/cc @benabraham

Do kontejneru s aplikací jsem doinstaloval a nakonfiguroval nginx. Ten z `/2023` servíruje aktuální ročník, z `/2015` - `/2020` roky minulé.

V `urls.py` jsem musel všem adresám aplikace nastavit aktuální rok jako prefix. Platí to i pro admin rozhraní (`/2023/admin/` a `/2023/wagtail/`), pokud by v tomto případě byla změna URL adres problém, tak to můžu případně ještě změnit.

Archiv se stahuje z repa `pyvec/cz.pycon.org-2019` při deplymentu do fly.io. Při nějaké změně v archivovaných souborech je tedy nutné i nasadit novou verzi do fly.io. Změny budou ale asi výjimečné, takže nepředpokládám, že by to byl problém. Nabízelo se také použití git submodulů, ale ty jen nutné aktualizovat zvlášť, což by byl zbytečný krok navíc.

Pár poznámek ke konfiguraci:

* Pro všechny "textové" zdroje je nastavená komprese pomocí gzip (běžně dostupný nginx nepodporuje brotli).
* Soubory z `/media` mají nastavené cachování na 1 rok. Soubory by se tedy neměly aktualizovat, ale nová verze by se měla nahrát pod jiným jménem. To samé platí i pro `/static`, tam by to ale za nás měl řešit whitenoise, fly by navíc mělo statické soubory vytáhnout a servírovat samo.
* U archivu minulých ročníků jsem zatím nastavil, aby se nic necachovalo a aby si prohlížeč vždy ověřil, jestli neexistuje novější verze.
* V kontejneru se startují 2 hlavní procesy `gunicorn` a `nginx` (směruje určité požadavky na gunicorn). K tomu jsem použil multirun, který je dostatečně jednoduchý: https://nicolas-van.github.io/multirun/
* Provedl jsem také pár drobných úprav v Dockerfile, aby měl výsledný image méně vrstev.