### PR TITLE
Fix static files on fly.io

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,14 @@ RUN --mount=type=bind,source=./requirements.txt,target=/tmp/requirements.txt \
     echo "error_log /dev/stdout info;" >> /etc/nginx/nginx.conf
 COPY . /code
 
+# Prepare the application
+RUN set -ex; \
+    # Use fake values for required environment variables - manage.py would fail to start without these variables. \
+    export DATABASE_URL=postgres://localhost/fake_db; \
+    export SECRET_KEY=notasecret; \
+    # Collect static files
+    python manage.py collectstatic --noinput;
+
 EXPOSE 8000
 
 CMD ["multirun", "gunicorn --bind unix:/code/gunicorn.sock --workers 2 wsgi", "nginx -g \"daemon off;\""]

--- a/docker/nginx/cz.pycon.org.conf
+++ b/docker/nginx/cz.pycon.org.conf
@@ -33,7 +33,7 @@ server
 
     location /static
     {
-        alias /code/static;
+        alias /code/staticfiles;
         # Static assets, such as stylesheets ans JS, should be immutable. Cache for a long time.
         expires 365d;
         add_header Cache-Control public;

--- a/fly.toml
+++ b/fly.toml
@@ -7,7 +7,7 @@ app = "pycon-cz-beta"
 primary_region = "ams"
 
 [deploy]
-  release_command = "bash -c \"python manage.py migrate && python manage.py collectstatic --noinput\""
+  release_command = "bash -c \"python manage.py migrate\""
 
 [env]
   PORT = "8000"
@@ -19,7 +19,7 @@ primary_region = "ams"
   auto_start_machines = true
 
 [[statics]]
-  guest_path = "/code/static"
+  guest_path = "/code/staticfiles"
   url_prefix = "/static/"
 
 [mounts]


### PR DESCRIPTION
Statické soubory ve fly.io byly nasměrovány do jiné složky: posbírají se do složky `/code/staticfiles`, ale ve fly.io bylo nasměrováno do `/code/static`. Zároveň jsem volání `manage.py collectstatic` přesunul do Dockerfile, protože jsem si všiml, že po restartu stroje se příkazy nastavené v `release_command` nevolají a složka `/code/staticfiles` neexistovala. To by způsobilo problémy, protože whitenoise potřebuje manifest, který si při `collectstatic` vygeneruje.