### PR TITLE
Fly deployments: beta + production

### DIFF
--- a/.github/workflows/deploy_beta.yaml
+++ b/.github/workflows/deploy_beta.yaml
@@ -1,8 +1,8 @@
-name: Fly Deploy
+name: Fly Deploy - beta
 on:
   push:
     branches:
-      - main
+      - beta
 jobs:
   deploy:
     name: Deploy app

--- a/.github/workflows/deploy_production.yaml
+++ b/.github/workflows/deploy_production.yaml
@@ -1,0 +1,20 @@
+name: Fly Deploy - production
+on:
+  push:
+    branches:
+      - main
+jobs:
+  deploy:
+    name: Deploy app
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Checkout repository with archived sites of previous years
+        uses: actions/checkout@v3
+        with:
+          repository: pyvec/cz.pycon.org-2019
+          path: _previous-years
+      - uses: superfly/flyctl-actions/setup-flyctl@master
+      - run: flyctl deploy -c fly.prod.toml --remote-only
+        env:
+          FLY_API_TOKEN: ${{ secrets.FLY_API_TOKEN }}

--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -1,0 +1,30 @@
+# fly.toml app configuration file generated for pycon-cz-prod on 2023-05-29T16:52:14+02:00
+#
+# See https://fly.io/docs/reference/configuration/ for information about how to use this file.
+#
+
+app = "pycon-cz-prod"
+primary_region = "ams"
+
+[deploy]
+  release_command = "bash -c \"python manage.py migrate\""
+
+[env]
+  PORT = "8000"
+
+[http_service]
+  internal_port = 8000
+  force_https = true
+  auto_stop_machines = false
+  auto_start_machines = false
+
+[[statics]]
+  guest_path = "/code/staticfiles"
+  url_prefix = "/static/"
+
+[mounts]
+  source="django_images_data"
+  destination="/code/data"
+
+[regions]
+allow = ["ams"]


### PR DESCRIPTION
Vytvořena větev `beta`, která byla zároveň nastavená jako výchozí (tzn. PR budou defaultně směřovat do ní).

Zároveň doplněny akce pro automatické nasazení:

* větev `beta` -> aplikace `pycon-cz-beta` ve Fly.io
* větev `main` -> aplikace `pycon-cz-prod` ve Fly.io