### PR TITLE
Enable HTTP Basic auth when HTTP_AUTH env. var is set

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,7 +34,12 @@ RUN --mount=type=bind,source=./requirements.txt,target=/tmp/requirements.txt \
     # Configure logging for nginx
     sed -i 's|access_log /var/log/nginx/access.log;|access_log /dev/stdout combined;|g' /etc/nginx/nginx.conf && \
     sed -i 's|error_log /var/log/nginx/error.log;|error_log /dev/stdout info;|g' /etc/nginx/nginx.conf && \
-    echo "error_log /dev/stdout info;" >> /etc/nginx/nginx.conf
+    echo "error_log /dev/stdout info;" >> /etc/nginx/nginx.conf && \
+    # Prepare configuration required for dynamic configuration based on env. parameters
+    mkdir -p /etc/nginx/pycon-config-enabled/ && \
+    mkdir -p /etc/nginx/pycon-config-available/ && \
+    cp /tmp/nginx-conf/*.inc.conf /etc/nginx/pycon-config-available/
+
 COPY . /code
 
 # Prepare the application
@@ -43,11 +48,13 @@ RUN set -ex; \
     export DATABASE_URL=postgres://localhost/fake_db; \
     export SECRET_KEY=notasecret; \
     # Collect static files
-    python manage.py collectstatic --noinput;
+    python manage.py collectstatic --noinput; \
+    # Make nginx start script executable
+    chmod a+x /code/docker/nginx/start-nginx.sh;
 
 EXPOSE 8000
 
 ARG SENTRY_RELEASE=dev
 ENV SENTRY_RELEASE=${SENTRY_RELEASE}
 
-CMD ["multirun", "gunicorn --bind unix:/code/gunicorn.sock --workers 2 wsgi", "nginx -g \"daemon off;\""]
+CMD ["multirun", "gunicorn --bind unix:/code/gunicorn.sock --workers 2 wsgi", "/code/docker/nginx/start-nginx.sh"]

--- a/README.md
+++ b/README.md
@@ -48,16 +48,17 @@ The development server runs at the address http://0.0.0.0:8000/. Beta instance o
 The application can be configured using the following environment variables. Reasonable defaults for local  development
 are already set in the provided `docker-compose.yaml`.
 
-| Variable              | Description                                                                                                                            |
-|-----------------------|----------------------------------------------------------------------------------------------------------------------------------------|
-| `DATABASE_URL`        | *Required.* URL defining database connection parameter. See https://github.com/jazzband/dj-database-url#url-schema for syntax.         |
-| `SECRET_KEY`          | *Required.* Secret key for Django, will be used to sign cookies for the admin.                                                         |
-| `DEBUG`               | Set to `1` or `true` to enable Django debug mode. Debug mode is disabled by default.                                                   |
-| `EXTRA_ALLOWED_HOSTS` | Comma separated list of hosts to allow in addition to the production ones. Can be used for debugging production configuration locally. |
-| `DEFAULT_LOG_LEVEL`   | Log level for the root logger. Can be `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, or `CRITICAL`.                                    |
-| `SENTRY_DSN`          | DSN of the project in Sentry. When not set, Sentry will be disabled.                                                                   |
-| `SENTRY_RELEASE`      | Current release for Sentry reporting. Will be set to a short commit hash during deployment and baked to the Docker container.          |
-| `SENTRY_ENVIRONMENT`  | Identifier of the environment for Sentry reporting. Set in `fly.toml` and `fly.prod.toml` for beta and production.                     |                                                                                                                                    
+| Variable              | Description                                                                                                                                          |
+|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------|
+| `DATABASE_URL`        | *Required.* URL defining database connection parameter. See https://github.com/jazzband/dj-database-url#url-schema for syntax.                       |
+| `SECRET_KEY`          | *Required.* Secret key for Django, will be used to sign cookies for the admin.                                                                       |
+| `DEBUG`               | Set to `1` or `true` to enable Django debug mode. Debug mode is disabled by default.                                                                 |
+| `EXTRA_ALLOWED_HOSTS` | Comma separated list of hosts to allow in addition to the production ones. Can be used for debugging production configuration locally.               |
+| `DEFAULT_LOG_LEVEL`   | Log level for the root logger. Can be `DEBUG`, `INFO`, `WARNING` (default), `ERROR`, or `CRITICAL`.                                                  |
+| `SENTRY_DSN`          | DSN of the project in Sentry. When not set, Sentry will be disabled.                                                                                 |
+| `SENTRY_RELEASE`      | Current release for Sentry reporting. Will be set to a short commit hash during deployment and baked to the Docker container.                        |
+| `SENTRY_ENVIRONMENT`  | Identifier of the environment for Sentry reporting. Set in `fly.toml` and `fly.prod.toml` for beta and production.                                   |
+| `HTTP_AUTH`           | When set, `nginx` will enable HTTP Basic Auth and use contents of this variable as its htpasswd file. No effect when running with Django dev server. |
 
 ### Contributing
 If you want to contribute, please run `make lint` before pushing BE code to format it. This step will be automated in the future.

--- a/docker/nginx/10-http-auth.inc.conf
+++ b/docker/nginx/10-http-auth.inc.conf
@@ -1,0 +1,2 @@
+auth_basic "PyCon CZ Beta site";
+auth_basic_user_file /etc/nginx/htpasswd;

--- a/docker/nginx/cz.pycon.org.conf
+++ b/docker/nginx/cz.pycon.org.conf
@@ -13,6 +13,9 @@ server
     gzip on;
     gzip_types text/plain text/css application/json application/x-javascript application/javascript text/xml application/xml application/xml+rss text/javascript image/svg+xml;
 
+    # Include dynamic configuration - files symlinked by the start-nginx.sh script.
+    include /etc/nginx/pycon-config-enabled/*.conf;
+
     # Redirect to the current year.
     location = /
     {

--- a/docker/nginx/start-nginx.sh
+++ b/docker/nginx/start-nginx.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+if [ -n "${HTTP_AUTH}" ]; then
+  echo "Enabling HTTP Auth, using htpasswd file from the HTTP_AUTH env. variable."
+  ln -s /etc/nginx/pycon-config-available/10-http-auth.inc.conf /etc/nginx/pycon-config-enabled/10-http-auth.inc.conf
+  echo "${HTTP_AUTH}" > /etc/nginx/htpasswd
+fi
+
+exec nginx -g "daemon off;"


### PR DESCRIPTION
Beta nakonfigurována, aby vyžadovala HTTP Auth, htpasswd nastaven jako secret ve fly.io (heslo napíšu na Slack).

Resolves #11.