### PR TITLE
Improvements of admin for speakers, talks, and workshops

### DIFF
--- a/program/admin.py
+++ b/program/admin.py
@@ -88,6 +88,12 @@ class SpeakerAdmin(admin.ModelAdmin):
     ]
     actions = [make_public, speaker_update_from_pretalx]
 
+    def get_readonly_fields(self, request, obj=None):
+        ro_fields: list = super().get_readonly_fields(request, obj)
+        if obj is not None and not obj.pretalx_code:
+            ro_fields = ro_fields + ["pretalx_code"]
+        return ro_fields
+
 
 @admin.action(description="Update from pretalx")
 def talk_update_from_pretalx(modeladmin, request, queryset):
@@ -171,6 +177,12 @@ class TalkAdmin(admin.ModelAdmin):
     @admin.display(description="Speakers", empty_value="not set")
     def speakers(self, talk: Talk) -> str:
         return ", ".join(speaker.full_name for speaker in talk.talk_speakers.all())
+
+    def get_readonly_fields(self, request, obj=None):
+        ro_fields: list = super().get_readonly_fields(request, obj)
+        if obj is not None and not obj.pretalx_code:
+            ro_fields = ro_fields + ["pretalx_code"]
+        return ro_fields
 
 
 @admin.action(description="Update from pretalx")
@@ -266,3 +278,9 @@ class WorkshopAdmin(admin.ModelAdmin):
         return ", ".join(
             speaker.full_name for speaker in workshop.workshop_speakers.all()
         )
+
+    def get_readonly_fields(self, request, obj=None):
+        ro_fields: list = super().get_readonly_fields(request, obj)
+        if obj is not None and not obj.pretalx_code:
+            ro_fields = ro_fields + ["pretalx_code"]
+        return ro_fields

--- a/program/admin.py
+++ b/program/admin.py
@@ -94,6 +94,14 @@ class SpeakerAdmin(admin.ModelAdmin):
             ro_fields = ro_fields + ["pretalx_code"]
         return ro_fields
 
+    def save_model(self, request, obj: Speaker, form, change: bool) -> None:
+        obj.save()
+
+        if not change and obj.pretalx_code:
+            sync = create_pretalx_sync()
+            sync.update_speakers([obj])
+
+
 
 @admin.action(description="Update from pretalx")
 def talk_update_from_pretalx(modeladmin, request, queryset):
@@ -183,6 +191,13 @@ class TalkAdmin(admin.ModelAdmin):
         if obj is not None and not obj.pretalx_code:
             ro_fields = ro_fields + ["pretalx_code"]
         return ro_fields
+
+    def save_model(self, request, obj: Talk, form, change: bool) -> None:
+        obj.save()
+
+        if not change and obj.pretalx_code:
+            sync = create_pretalx_sync()
+            sync.update_talks([obj])
 
 
 @admin.action(description="Update from pretalx")
@@ -284,3 +299,10 @@ class WorkshopAdmin(admin.ModelAdmin):
         if obj is not None and not obj.pretalx_code:
             ro_fields = ro_fields + ["pretalx_code"]
         return ro_fields
+
+    def save_model(self, request, obj: Workshop, form, change: bool) -> None:
+        obj.save()
+
+        if not change and obj.pretalx_code:
+            sync = create_pretalx_sync()
+            sync.update_workshops([obj])

--- a/program/admin.py
+++ b/program/admin.py
@@ -26,23 +26,54 @@ def speaker_update_from_pretalx(modeladmin, request, queryset):
 
 @admin.register(Speaker)
 class SpeakerAdmin(admin.ModelAdmin):
-    list_display = ["full_name", "email", "is_public", "display_position", "pretalx_code"]
-    search_fields = ["full_name", "email"]
-    ordering = ["full_name"]
-    fields = [
-        "pretalx_code",
+    list_display = [
+        "full_name",
+        "email",
         "is_public",
         "display_position",
-        "photo",
-        "talks",
-        "workshops",
-        "bio",
-        "short_bio",
-        "twitter",
-        "github",
-        "linkedin",
-        "personal_website",
-        "email",
+        "pretalx_code",
+    ]
+    search_fields = ["full_name", "email"]
+    ordering = ["full_name"]
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": [
+                    "pretalx_code",
+                    "short_bio",
+                    "bio",
+                    "photo",
+                ],
+            },
+        ),
+        (
+            "Display",
+            {
+                "fields": [
+                    "is_public",
+                    "display_position",
+                ],
+            },
+        ),
+        (
+            "Contacts",
+            {
+                "fields": [
+                    "twitter",
+                    "github",
+                    "linkedin",
+                    "personal_website",
+                    "email",
+                ],
+            },
+        ),
+        (
+            "Speaker",
+            {
+                "fields": ["talks", "workshops"],
+            },
+        ),
     ]
     readonly_fields = [
         "full_name",
@@ -52,6 +83,8 @@ class SpeakerAdmin(admin.ModelAdmin):
         "github",
         "linkedin",
         "personal_website",
+        "talks",
+        "workshops",
     ]
     actions = [make_public, speaker_update_from_pretalx]
 
@@ -79,21 +112,42 @@ class TalkAdmin(admin.ModelAdmin):
     list_filter = ["is_keynote", "track", "language", "is_public", "is_backup"]
     search_fields = ["title", "abstract", "talk_speakers__full_name", "pretalx_code"]
     ordering = ["is_backup", "-is_keynote", "track", "order", "title"]
-    fields = [
-        "pretalx_code",
-        "is_public",
-        "order",
-        "is_backup",
-        "og_image",
-        "video_id",
-        "private_note",
-        "language",
-        "track",
-        "type",
-        "minimum_python_knowledge",
-        "minimum_topic_knowledge",
-        "is_keynote",
-        "abstract",
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": [
+                    "pretalx_code",
+                    "og_image",
+                    "video_id",
+                ],
+            },
+        ),
+        (
+            "Display",
+            {
+                "fields": [
+                    ("is_public", "is_backup"),
+                    "order",
+                ],
+            },
+        ),
+        (
+            "Talk info (edit in pretalx)",
+            {
+                "fields": [
+                    "title",
+                    "track",
+                    "private_note",
+                    "type",
+                    "speakers",
+                    "language",
+                    "minimum_python_knowledge",
+                    "minimum_topic_knowledge",
+                    "abstract",
+                ],
+            },
+        ),
     ]
     readonly_fields = [
         "title",
@@ -139,27 +193,53 @@ class WorkshopAdmin(admin.ModelAdmin):
         "pretalx_code",
     ]
     list_filter = ["type", "track", "language", "is_public", "is_backup"]
-    search_fields = ["title", "abstract", "workshop_speakers__full_name", "pretalx_code"]
-    ordering = ["is_backup", "track", "order", "title"]
-    fields = [
-        "pretalx_code",
-        "is_public",
-        "order",
-        "is_sold_out",
-        "og_image",
-        "registration",
-        "length",
-        "is_backup",
-        "private_note",
-        "language",
-        "track",
-        "type",
-        "minimum_python_knowledge",
-        "minimum_topic_knowledge",
+    search_fields = [
+        "title",
         "abstract",
-        "requirements",
-        "attendee_limit",
-
+        "workshop_speakers__full_name",
+        "pretalx_code",
+    ]
+    ordering = ["is_backup", "track", "order", "title"]
+    fieldsets = [
+        (
+            None,
+            {
+                "fields": [
+                    "pretalx_code",
+                    "og_image",
+                    "registration",
+                    "length",
+                    "is_sold_out",
+                ],
+            },
+        ),
+        (
+            "Display",
+            {
+                "fields": [
+                    ("is_public", "is_backup"),
+                    "order",
+                ],
+            },
+        ),
+        (
+            "Workshop info (edit in pretalx)",
+            {
+                "fields": [
+                    "title",
+                    "track",
+                    "attendee_limit",
+                    "private_note",
+                    "type",
+                    "speakers",
+                    "language",
+                    "minimum_python_knowledge",
+                    "minimum_topic_knowledge",
+                    "requirements",
+                    "abstract",
+                ],
+            },
+        ),
     ]
     readonly_fields = [
         "title",


### PR DESCRIPTION
* Nastaveny fieldsets v adminu, aby byla editace přehlednější.
* Při aktualizacích jednotlivých talků/workshopů se k nim nepřiřazovali speakeři. To je nyní opraveno a pokud se přidá talk/workshop dříve, než jeho speakeři, tak se automaticky vytvoří (a informace se načtou z pretalxu).
* Pokud se přidá speaker/talk/workshop s vyplněným pretalx code, tak se při uložení hned načtou informace z pretalx.