### PR TITLE
Revert "make Safari behave better with multicol layout"

### DIFF
--- a/static_src/scss/_custom-utilities.scss
+++ b/static_src/scss/_custom-utilities.scss
@@ -22,7 +22,6 @@
 
     > * {
         break-inside: avoid-column;
-        display: -webkit-box; // make Safari behave
     }
 
 }


### PR DESCRIPTION
This reverts commit f5f5364a1f175eccd689da1e50ee685e4ecdf106.

It breaks ul - li alignment in bio at talk detail. Even in Safari.
Tested page: https://cz.pycon.org/2023/program/workshops/33/

Attached screenshot taken before this patch on Safari:
![image](https://github.com/pyvec/cz.pycon.org/assets/7302742/c7b5517a-d210-4bc8-b4ef-27f2c26169e7)
