### PR TITLE
Remove statics from fly.io configuration, they will be served by nginx

### DIFF
--- a/fly.prod.toml
+++ b/fly.prod.toml
@@ -19,10 +19,6 @@ primary_region = "ams"
   auto_stop_machines = false
   auto_start_machines = false
 
-[[statics]]
-  guest_path = "/code/staticfiles"
-  url_prefix = "/static/"
-
 [mounts]
   source="django_images_data"
   destination="/code/data"

--- a/fly.toml
+++ b/fly.toml
@@ -21,10 +21,6 @@ primary_region = "ams"
   auto_stop_machines = false
   auto_start_machines = true
 
-[[statics]]
-  guest_path = "/code/staticfiles"
-  url_prefix = "/static/"
-
 [mounts]
   source="django_images_data"
   destination="/code/data"


### PR DESCRIPTION
Fly.io sets inappropriate caching headers (max-age=0) disallowing client-side caching, and statics were downloaded on each page view.