### PR TITLE
Intermissions: talks and sponsors

### DIFF
--- a/intermissions/urls.py
+++ b/intermissions/urls.py
@@ -1,10 +1,10 @@
-from django.urls import re_path
+from django.urls import path
 
 from .views import announcements, index, slido, sponsors
 
 urlpatterns = [
-    re_path("^$", index, name="cycle_all"),
-    re_path("^sponsors/(?P<level>[\w\-]+)/$", sponsors, name="sponsors"),
-    re_path("^announcements/$", announcements, name="announcements"),
-    re_path("^slido/$", slido, name="slido"),
+    path("", index, name="cycle_all"),
+    path("sponsors/<level>/", sponsors, name="sponsors"),
+    path("announcements/", announcements, name="announcements"),
+    path("slido/", slido, name="slido"),
 ]

--- a/intermissions/urls.py
+++ b/intermissions/urls.py
@@ -1,10 +1,11 @@
 from django.urls import path
 
-from .views import announcements, index, slido, sponsors
+from .views import announcements, index, slido, sponsors, next_talk
 
 urlpatterns = [
     path("", index, name="cycle_all"),
     path("sponsors/<level>/", sponsors, name="sponsors"),
     path("announcements/", announcements, name="announcements"),
     path("slido/", slido, name="slido"),
+    path("next-talk/<int:page>", next_talk, name="next_talk"),
 ]

--- a/intermissions/views.py
+++ b/intermissions/views.py
@@ -1,17 +1,33 @@
+import datetime
+from urllib.parse import quote
+
+from django.http import HttpRequest, HttpResponse, Http404
 from django.template.response import TemplateResponse
 from django.shortcuts import get_object_or_404
-from django.db.models import Count
+from django.db.models import Count, Q
+from django.utils import timezone
 
 from announcements.models import Announcement
 from sponsors.models import Sponsor, Level
+from program.models import Slot
+from program.views import CONFERENCE_DAYS
+
+
+MAX_TALK_PAGE = 2
 
 
 def index(request):
-    levels  = {
-        l.slug for l in
-        Level.objects.annotate(sponsor_count=Count('sponsor')).filter(sponsor_count__gt=0)
+    levels = {
+        l.slug
+        for l in Level.objects.annotate(sponsor_count=Count("sponsor")).filter(
+            sponsor_count__gt=0
+        )
     }
-    
+
+    time_param = ""
+    if simulated_time := request.GET.get("time", None):
+        time_param = f"?time={quote(simulated_time)}"
+
     return TemplateResponse(
         request,
         template="intermissions/index.html",
@@ -20,6 +36,7 @@ def index(request):
             # then it's called every 10 seconds
             "interval": int(request.GET.get("interval", 10)) * 1000,
             "levels": levels,
+            "time_param": time_param,
         },
     )
 
@@ -30,13 +47,13 @@ def sponsors(request, level):
 
     first_sponsor = sponsors.first()
     # get readable display name for the passed level (integer)
-    
+
     return TemplateResponse(
         request,
         template="intermissions/sponsors.html",
         context={
             "sponsors": sponsors,
-            "level": level
+            "level": level,
         },
     )
 
@@ -56,3 +73,117 @@ def slido(request):
         request,
         template="intermissions/slido.html",
     )
+
+
+def next_talk(request: HttpRequest, page: int) -> HttpResponse:
+    # Only 2 pages is supported in this variant.
+    if page < 1 or page > MAX_TALK_PAGE:
+        raise Http404()
+
+    # You can simulate the time using the time GET parameter.
+    simulated_time = request.GET.get("time", None)
+
+    default_tz = timezone.get_default_timezone()
+    if simulated_time:
+        current_time = datetime.datetime.fromisoformat(simulated_time)
+        current_time = current_time.replace(tzinfo=default_tz)
+
+    else:
+        current_time = timezone.now()
+        # Hey, you might try this before the conference starts!
+        # Simulate the first day of the conference.
+        conference_start_date = min(CONFERENCE_DAYS.values())
+        conference_start = datetime.datetime.combine(
+            date=conference_start_date,
+            time=datetime.time(9, 0),
+            tzinfo=default_tz,
+        )
+        if current_time < conference_start:
+            current_time = conference_start
+
+    upcoming_slots = _get_upcoming_slots(current_time)
+    upcoming_slots, streamed = _detect_streamed_slots(upcoming_slots)
+    slide_slots = _get_slots_for_page(upcoming_slots, page)
+
+    return TemplateResponse(
+        request,
+        "intermissions/next_talk.html",
+        context={
+            "slots": slide_slots,
+            "streamed": streamed,
+        },
+    )
+
+
+def _get_upcoming_slots(current_time: datetime.datetime) -> list[Slot]:
+    # Add 5 minutes start tolerance - just in case something goes wrong on-site
+    # and the talk starts a bit late.
+    start_time = current_time - datetime.timedelta(minutes=5)
+    # On Saturday, some rooms are empty until afternoon - don't advertise them early.
+    start_time_max = current_time + datetime.timedelta(hours=1, minutes=15)
+    upcoming_slots = (
+        Slot.objects.filter(
+            start__gte=start_time,
+            start__lte=start_time_max,
+        )
+        .filter(
+            # Lunch is inevitable, no need to advertise it.
+            # Show only talks or streamed utilities.
+            Q(talk_id__isnull=False)
+            | Q(utility_id__isnull=False, utility__is_streamed=True)
+        )
+        .distinct(
+            # Generates a DISTINCT ON() clause, which returns only the first row
+            # with the given value - will return only the next upcoming slot
+            # for each room.
+            "room_id"
+        )
+        .select_related(
+            "room",
+            "talk",
+            "utility",
+        )
+        .order_by(
+            # Column used in DISTINCT ON must be the first column in ORDER BY
+            "room_id",
+            "start",
+        )
+    )
+
+    # Sort the slots by room order in Python (sorting 4 rows should be fast enough).
+    # For more rooms, sorting in database using a subquery might be more efficient.
+    result = list(upcoming_slots)
+    result.sort(key=lambda slot: slot.room.order)
+    return result
+
+
+def _detect_streamed_slots(upcoming_slots: list[Slot]) -> tuple[list[Slot], bool]:
+    streamed = False
+    result = []
+    for slot in upcoming_slots:
+        if result and slot.is_same_for_different_room(result[-1]):
+            streamed = True
+            continue
+
+        result.append(slot)
+        if slot.utility is not None and slot.utility.is_streamed:
+            streamed = True
+
+    return result, streamed
+
+
+def _get_slots_for_page(slots: list[Slot], page) -> list[Slot]:
+    # If there is only 1 slot, show it on both pages.
+    if len(slots) == 1:
+        return slots
+
+    # If there are 2 slots, show each one on its own page.
+    if len(slots) == 2:
+        return slots[page - 1 : page]
+
+    # In case of 3 slots, put 1 slot on the first page, 2 on the second page.
+    # This expression might be too complex for this simple case,
+    # but it allows adding more pages in the future.
+    start_index = max(0, len(slots) - (MAX_TALK_PAGE - page + 1) * 2)
+    end_index = len(slots) - (MAX_TALK_PAGE - page) * 2
+    return slots[start_index:end_index]

--- a/static_src/scss/custom-components/_PC-intermission.scss
+++ b/static_src/scss/custom-components/_PC-intermission.scss
@@ -1,0 +1,10 @@
+.PC-intermission-slots {
+    display: grid;
+    grid-template-rows: auto;
+    grid-auto-columns: 1fr;
+    flex-grow: 1;
+}
+
+.PC-intermission-slots-item {
+    padding: map-get($spacers, 4);
+}

--- a/static_src/scss/custom-components/_PC-intermission.scss
+++ b/static_src/scss/custom-components/_PC-intermission.scss
@@ -8,3 +8,28 @@
 .PC-intermission-slots-item {
     padding: map-get($spacers, 4);
 }
+
+.PC-intermission-sponsors-levels-grid {
+    display: grid;
+    grid-template-rows: auto;
+    grid-auto-columns: 1fr;
+    flex-grow: 1;
+}
+
+.PC-intermission-sponsors-levels-item {
+    padding: map-get($spacers, 4);
+}
+
+.PC-intermission-sponsors {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: map-get($spacers, 6);
+}
+
+.PC-intermission-sponsors-item {
+    height: 200px;
+    width: 400px;
+    display: grid;
+    place-items: center;
+}

--- a/static_src/scss/index.scss
+++ b/static_src/scss/index.scss
@@ -77,6 +77,7 @@
 // Custom components
 @import "custom-components/PC-header";
 @import "custom-components/PC-image";
+@import "custom-components/PC-intermission";
 @import "custom-components/PC-language";
 @import "custom-components/PC-og";
 @import "custom-components/PC-schedule";

--- a/templates/_base.html
+++ b/templates/_base.html
@@ -40,11 +40,14 @@
     <body {% block body_extras %}{% endblock %}>
     {% block body %}{% endblock %}
     {% comment %}<script src="{% static 'generated/bootstrap.bundle.min.js' %}"></script>{% endcomment %}
-    {% if not debug %}
-        <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
-        <script async src="https://scripts.simpleanalyticscdn.com/auto-events.js"></script>
-        <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt="" referrerpolicy="no-referrer-when-downgrade"></noscript>
-    {% endif %}
+    {% block analytics %}
+        {% if not debug %}
+            <script async defer src="https://scripts.simpleanalyticscdn.com/latest.js"></script>
+            <script async src="https://scripts.simpleanalyticscdn.com/auto-events.js"></script>
+            <noscript><img src="https://queue.simpleanalyticscdn.com/noscript.gif" alt=""
+                           referrerpolicy="no-referrer-when-downgrade"></noscript>
+        {% endif %}
+    {% endblock %}
     {% block after_scripts_loaded %}{% endblock %}
     </body>
     </html>

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -24,15 +24,21 @@
         "use strict";
         const urls = [
             '{% url 'announcements' %}',
+            '{% url 'next_talk' page=1 %}{{ time_param }}',
+            '{% url 'next_talk' page=2 %}{{ time_param }}',
             '{% url 'slido' %}',
             {% if 'platinum' in levels %}
                 '{% url 'sponsors' level='platinum' %}',
                 '{% url 'announcements' %}',
+                '{% url 'next_talk' page=1 %}{{ time_param }}',
+                '{% url 'next_talk' page=2 %}{{ time_param }}',
                 '{% url 'slido' %}',
             {% endif %}
             {% if 'gold' in levels %}'{% url 'sponsors' level='gold' %}',{% endif %}
             {% if 'silver' in levels %}'{% url 'sponsors' level='silver' %}',{% endif %}
             '{% url 'announcements' %}',
+            '{% url 'next_talk' page=1 %}{{ time_param }}',
+            '{% url 'next_talk' page=2 %}{{ time_param }}',
             '{% url 'slido' %}',
             {% if 'bronze' in levels %}'{% url 'sponsors' level='bronze' %}',{% endif %}
             {% if 'partners' in levels %}'{% url 'sponsors' level='partners' %}',{% endif %}

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -38,9 +38,16 @@
             {% if 'partners' in levels %}'{% url 'sponsors' level='partners' %}',{% endif %}
         ];
 
+        console.groupCollapsed(
+            'Intermissions: ' + urls.length + ' slides available, full cycle takes ' + (urls.length * {{ interval }} / 1000) + ' s'
+        );
+        console.table(urls);
+        console.groupEnd();
+
         let now = -1;
         let active = true;
         const show_current = () => {
+            console.debug("[%d] %s", now, urls[now]);
             fetch(urls[now]).then((response) => response.text()).then((data) => {
                 document.getElementById('intermission-content').innerHTML = data;
             });

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -35,7 +35,8 @@
                 '{% url 'slido' %}',
             {% endif %}
             {% if 'gold' in levels %}'{% url 'sponsors' level='gold' %}',{% endif %}
-            {% if 'silver' in levels %}'{% url 'sponsors' level='silver' %}',{% endif %}
+            {% if 'silver' in levels %}'{% url 'sponsors' level='silver[:6]' %}',{% endif %}
+            {% if 'silver' in levels %}'{% url 'sponsors' level='silver[6:]' %}',{% endif %}
             '{% url 'announcements' %}',
             '{% url 'next_talk' page=1 %}{{ time_param }}',
             '{% url 'next_talk' page=2 %}{{ time_param }}',

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -64,11 +64,11 @@
         const handle_keydown = (event) => {
             if (["ArrowDown", "ArrowLeft", "PageDown"].includes(event.key)){
                 active = false;
-                next();
+                prev();
             }
             if (["ArrowUp", "ArrowRight", "PageUp"].includes(event.key)){
                 active = false;
-                prev();
+                next();
             }
             if (event.key === ' '){
                 active = !active;

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -35,6 +35,7 @@
                 '{% url 'slido' %}',
             {% endif %}
             {% if 'gold' in levels %}'{% url 'sponsors' level='gold' %}',{% endif %}
+            {% if 'coffee' in levels or 'afterparty' in levels %}'{% url 'sponsors' level="coffee,afterparty" %}',{% endif %}
             {% if 'silver' in levels %}'{% url 'sponsors' level='silver[:6]' %}',{% endif %}
             {% if 'silver' in levels %}'{% url 'sponsors' level='silver[6:]' %}',{% endif %}
             '{% url 'announcements' %}',

--- a/templates/intermissions/index.html
+++ b/templates/intermissions/index.html
@@ -9,6 +9,10 @@
 
 {% block body_extras %}style="overflow:hidden;"{% endblock %}
 
+{# Disable Simple Analytics #}
+{% block analytics %}
+{% endblock %}
+
 
 {% block body %}
     <main role="main" class="pc-intermission" id="intermission-content"></main>

--- a/templates/intermissions/next_talk.html
+++ b/templates/intermissions/next_talk.html
@@ -1,0 +1,43 @@
+{% load static %}
+<div class="pc-intermission-content">
+    <div class="d-flex flex-wrap h-100 align-content-around pb-7">
+        <div class="PC-intermission-slots">
+            {% for slot in slots %}
+            <div class="PC-intermission-slots-item" style="grid-column: {{ forloop.counter }}">
+                <h1 class="fw-normal{% if slots|length == 1 %} dis{% endif %}">
+                    Next up in
+                    <strong>{{ slot.room }}</strong>
+                    from
+                    <strong>{{ slot.start|date:"H:i" }}</strong>
+                    {% if streamed %}
+                        <span class="text-muted">
+                            (streamed to other rooms)
+                        </span>
+                    {% endif %}
+                </h1>
+
+                <h2>{{ slot.event.title }}</h2>
+
+                {% if slot.event.language == 'cs' %}
+                    <p class="PC-language">
+                        <img src="{% static 'img/flag-cz.svg' %}" width="32" height="32" alt="">
+                        <span class="PC-language-label">
+                            this
+                            {% if slot.event.type == 'panel' and slot.event.speakers|length == 1 %}
+                                discussion
+                            {% else %}
+                                {{ slot.event.type }}
+                            {% endif %}
+                            will be in Czech only
+                        </span>
+                    </p>
+                {% endif %}
+
+                <p class="PC-intermission-speakers">
+                    {% for speaker in slot.event.speakers %}{% if forloop.last and not forloop.first %} <span class="d-inline-block">&amp; {% elif not forloop.first %},</span> <span class="d-inline-block">{% endif %}{% spaceless %}{{ speaker.full_name }}{% if forloop.last %}</span>{% endif %}{% endspaceless %}{% endfor %}
+                </p>
+            </div>
+            {% endfor %}
+        </div>
+    </div>
+</div>

--- a/templates/intermissions/sponsors.html
+++ b/templates/intermissions/sponsors.html
@@ -1,14 +1,22 @@
 <div class="pc-intermission-content bg-white text-dark">
-    <h1 class="pc-intermission-heading display-1 mt-6">
-        Our <strong>{{ level.title }}</strong>
-        {% if level.slug != 'partners' %}sponsor{{ sponsors|pluralize:'s' }}{% endif %}
-    </h1>
+    <div class="PC-intermission-sponsors-levels-grid">
+        {% for level, sponsors in sponsor_lists %}
+            <div class="PC-intermission-sponsors-levels-item" style="grid-column: {{ forloop.counter }}">
+                <h1 class="pc-intermission-heading display-1 mt-6">
+                    Our <strong>{{ level.title }}</strong>
+                </h1>
 
-    <div class="pc-intermission-sponsors">
-        {% for sponsor in sponsors %}
-            <div class="pc-intermission-sponsors-item pc-intermission-sponsors-item-{{ level.title|lower }}">
-                {{ sponsor }}
+                <div class="PC-intermission-sponsors">
+                    {% for sponsor in sponsors %}
+                        <div class="PC-intermission-sponsors-item PC-intermission-sponsors-item-{{ level.title|lower }}">
+                            <img class="PC-sponsor-detail-logo img-fluid PC-img-fluid-svg"
+                                 src="{{ sponsor.logo.url }}"
+                                 alt="{{ sponsor.name }}"/>
+                        </div>
+                    {% endfor %}
+                </div>
             </div>
         {% endfor %}
     </div>
+
 </div>


### PR DESCRIPTION
## Integrace se sloty

Zobrazují se 2 slidy s dalším talkem či streamovanou utility ze všech místností - uvažují se talky začínající v následující 1h 15m, abychom v sobotu dopoledne zbytečně nepromovali místnost `__doc__`, kde je něco až odpoledne. Talk se taky bude zobrazovat ještě 5 minut po plánovaném začátku, aby v případě zpoždění ještě chvilku zobrazovalo, co kde začíná.

S aktuálním programem můžou nastat 3 situace:

* Následuje 1 talk: na obou slidech je stejný talk - bude to keynote/welcome/lightning, tak asi neva, když bude svítit o něco déle.
* Následují 3 talky: na prvním slidu bude 1 (ten z hlavní místnosti), na druhém 2.
* Následují 4 talky: zobrazení 2 + 2.

Talky mají zatím úplně základní šablonu a layout.


## Sponzoři

Při zadání levelu jde použít slicing, např: `silver[:6]` + `silver[6:]`, zároveň těch levelů jde zadat více a zobrazí se vedle sebe, např. `coffee,afterparty`.

Přidal jsem rendering loga a opět úplně základní layout, bude potřeba určitě ještě vyřešit velikosti atd.


## Další drobné změny

* Obrátil jsem ovládání pomocí šipek, doprava je nyní další slide, dříve to bylo obráceně.
* Do konzole v prohlížeči se vypisuje počet slidů a celková doba trvání cyklu + další debug informace (na něco je potřeba si explicitně zapnout level "verbose").