### PR TITLE
Use the less intrusive youtube-nocookie.com embed on the homepage

### DIFF
--- a/templates/pages/homepage.html
+++ b/templates/pages/homepage.html
@@ -150,7 +150,7 @@
             </div>
 
             <div class="ratio ratio-16x9">
-                <iframe width="960" height="407" src="https://www.youtube.com/embed/kL2gmhs0irI" allowfullscreen></iframe>
+                <iframe width="960" height="407" src="https://www.youtube-nocookie.com/embed/kL2gmhs0irI" allowfullscreen></iframe>
             </div>
         </div>
     </div>


### PR DESCRIPTION
Note: it uses local storage and is able to track the user, but at least it does not associate his visit with his Google Account.